### PR TITLE
remove use of 3rd party lib in setup.py, so pip install can work

### DIFF
--- a/PackageInfo.cfg
+++ b/PackageInfo.cfg
@@ -1,12 +1,12 @@
-# package info
-PACKAGE = pyfscache
-MAJOR = 0
-MINOR = 9
-MICRO = 11
-TAG = 
-AUTHOR = James C. Stroud
-EMAIL = jstroud@mbi.ucla.edu
-URL = http://pyfscache.bravais.net
-LICENSE = BSD
-COPYRIGHT = Copyright (c) 2013, James C. Stroud; All rights reserved.
-DESCRIPTION = A file system cache for python.
+[main]
+package: pyfscache
+major: 0
+minor: 9
+micro: 12
+tag: 
+author: James C. Stroud
+email: jstroud@mbi.ucla.edu
+url: http://pyfscache.bravais.net
+license: BSD
+copyright: Copyright (c) 2013, James C. Stroud; All rights reserved.
+description: A file system cache for python.

--- a/setup.py
+++ b/setup.py
@@ -2,27 +2,31 @@
 
 import os
 
+from ConfigParser import ConfigParser
 from setuptools import setup, find_packages
 
-import configobj
 
-info = configobj.ConfigObj('PackageInfo.cfg')
+config = ConfigParser()
+config.read('PackageInfo.cfg')
+info = dict(config.items('main'))
 
-setup(name = info['PACKAGE'],
-      version = "%(MAJOR)s.%(MINOR)s.%(MICRO)s%(TAG)s" % info,
-      author = info['AUTHOR'],
-      author_email = info['EMAIL'],
-      url = info['URL'],
-      description = info['DESCRIPTION'],
-      license = info['LICENSE'],
-      long_description = open('README.rst').read(),
-      packages = find_packages(),
-      package_data = {'':[os.path.join('*', '*.*')]},
-      include_package_data = True,
-      # requires = [],
-      test_suite = info['PACKAGE'] + '.tests.test_suite',
-      classifiers = [
-            'Programming Language :: Python :: 2.5',
-            'Programming Language :: Python :: 2.6',
-            'Programming Language :: Python :: 2.7', ],
-      )
+setup(
+    name=info['package'],
+    version="%(major)s.%(minor)s.%(micro)s%(tag)s" % info,
+    author=info['author'],
+    author_email=info['email'],
+    url=info['url'],
+    description=info['description'],
+    license=info['license'],
+    long_description=open('README.rst').read(),
+    packages=find_packages(),
+    package_data={'': [os.path.join('*', '*.*')]},
+    include_package_data=True,
+    # requires=[],
+    test_suite=info['package'] + '.tests.test_suite',
+    classifiers=[
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+    ],
+)


### PR DESCRIPTION
Currently setup.py uses a 3rd party lib `configobj`... easy_install & pip have no way to know they need to install this lib before attempting to install pyfscache so installing from pypi fails.

Using `configobj` seems pointless since stdlib has `ConfigParser` which has basically same functionality, so I just swapped to using that.

This change should mean pyfscache can install cleanly from pypi.
